### PR TITLE
add griffe to make mkdocs work

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -849,13 +849,13 @@ test = ["objgraph", "psutil"]
 
 [[package]]
 name = "griffe"
-version = "1.5.4"
+version = "0.49.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.8"
 files = [
-    {file = "griffe-1.5.4-py3-none-any.whl", hash = "sha256:ed33af890586a5bebc842fcb919fc694b3dc1bc55b7d9e0228de41ce566b4a1d"},
-    {file = "griffe-1.5.4.tar.gz", hash = "sha256:073e78ad3e10c8378c2f798bd4ef87b92d8411e9916e157fd366a17cc4fd4e52"},
+    {file = "griffe-0.49.0-py3-none-any.whl", hash = "sha256:c0d505f2a444ac342b22f4647d6444c8db64964b6a379c14f401fc467c0741a3"},
+    {file = "griffe-0.49.0.tar.gz", hash = "sha256:a7e1235c27d8139e0fd24a5258deef6061bc876a9fda8117a5cf7b53ee940a91"},
 ]
 
 [package.dependencies]
@@ -3361,4 +3361,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "adea2b3712a57c1135b4f03e1677effbb3a36282f1e4bd2110b4defdd7a04794"
+content-hash = "31de3e13f95888d89625898395b4f193b2bd2eb31c721c7252ef7e94450a6792"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ requests = "^2.31.0"
 langchain = "^0.1.0"
 langchain-core = "^0.1.31"
 types-requests = "^2.31.0.20240106"
+griffe = "0.49.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Manually tested by running `poetry run mkdocs gh-deploy --quiet --force`