### PR TITLE
upgrade to latest version of actions/cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: cache poetry install
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local
         key: poetry
@@ -39,7 +39,7 @@ jobs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -70,7 +70,7 @@ jobs:
         python-version: '3.11'
 
     - name: cache poetry install
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local
         key: poetry
@@ -82,7 +82,7 @@ jobs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: 3.11
 
     - name: cache poetry install
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local
         key: poetry
@@ -40,7 +40,7 @@ jobs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: cache poetry install
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local
         key: poetry
@@ -41,7 +41,7 @@ jobs:
 
     - name: Load cached venv
       id: cached-poetry-dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: .venv
         key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}


### PR DESCRIPTION
actions/cache@v2 is not supported anymore, so we need to move to a newer version.